### PR TITLE
build for 2.1. Use JCL Over slf4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,13 +6,18 @@
     <artifactId>otsdb-elasticsearch</artifactId>
     <version>1.0</version>
     <description>A search plugin for OpenTSDB that works with an Elastic Search cluster over HTTP.</description>
-    
+
     <contributors>
         <contributor>
             <name>Chris Larsen</name>
             <email>clarsen@euphoriaaudio.com</email>
         </contributor>
+        <contributor>
+            <name>Scott Reynolds</name>
+            <email>scott@scottreynolds.us</email>
+        </contributor>
     </contributors>
+
     <repositories>
         <repository>
             <id>mcaprari-releases</id>
@@ -23,74 +28,74 @@
             <url>https://github.com/mcaprari/mcaprari-maven-repo/raw/master/snapshots</url>
         </repository>
     </repositories>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.2.3</version>
+            <version>4.3.2</version>
         </dependency>
-        
+
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
-            <version>4.2.3</version>
+            <version>4.3.2</version>
         </dependency>
-        
+
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>fluent-hc</artifactId>
-            <version>4.2.3</version>
+            <version>4.3.5</version>
         </dependency>
-        
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <version>1.7.7</version>
+        </dependency>
         <dependency>
             <groupId>httpfailover</groupId>
             <artifactId>httpclient-failover</artifactId>
             <version>1.0</version>
         </dependency>
-        
+
         <dependency>
             <groupId>net.opentsdb</groupId>
             <artifactId>opentsdb</artifactId>
-            <version>2.0.0</version>
+            <version>2.1.0</version>
         </dependency>
-        
-        <dependency>
-            <groupId>com.stumbleupon</groupId>
-            <artifactId>async</artifactId>
-            <version>1.3.1</version>
-        </dependency>
-        
+
         <dependency>
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
           <version>13.0.1</version>
         </dependency>
-        
+
         <dependency>
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-annotations</artifactId>
-          <version>2.1.4</version>
+          <version>2.3.0</version>
         </dependency>
-        
+
         <dependency>
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-core</artifactId>
-          <version>2.1.4</version>
+          <version>2.3.3</version>
         </dependency>
-        
+
         <dependency>
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-databind</artifactId>
-          <version>2.1.4</version>
+          <version>2.3.3</version>
         </dependency>
     </dependencies>
-    
+
     <packaging>jar</packaging>
-    
+
     <build>
       <sourceDirectory>src</sourceDirectory>
       <testSourceDirectory>test</testSourceDirectory>
-      
+
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -100,6 +105,75 @@
                         <id>attach-sources</id>
                         <goals>
                             <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>1.6</version>
+                <configuration>
+                    <minimizeJar>true</minimizeJar>
+                    <createDependencyReducedPom>true</createDependencyReducedPom>
+                    <artifactSet>
+                        <excludes>
+                            <exclude>io.netty:netty</exclude>
+                            <exclude>commons-logging:*</exclude>
+                            <exclude>net.opentsdb:opentsdb</exclude>
+                            <exclude>com.stumbleupon:async</exclude>
+                            <exclude>org.apache.zookeeper:zookeeper</exclude>
+                            <exclude>org.hbase:asynchbase</exclude>
+                            <exclude>com.google.protobuf:protobuf</exclude>
+                            <exclude>com.google.gwt:gwt-user</exclude>
+                        </excludes>
+                    </artifactSet>
+
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>META-INF/*.SF</exclude>
+                                <exclude>META-INF/*.DSA</exclude>
+                                <exclude>META-INF/*.RSA</exclude>
+                            </excludes>
+                        </filter>
+                        <filter>
+                            <artifact>net.opentsdb:opentsdb</artifact>
+                            <excludes>
+                                <exclude>**</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
+                    <transformers>
+                        <transformer
+                            implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                            <resource>reference.conf</resource>
+                        </transformer>
+                    </transformers>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>eu.somatik.serviceloader-maven-plugin</groupId>
+                <artifactId>serviceloader-maven-plugin</artifactId>
+                <version>1.0.2</version>
+                <configuration>
+                    <services>
+                        <param>net.opentsdb.search.SearchPlugin</param>
+                    </services>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/src/META-INF/MANIFEST.MF
+++ b/src/META-INF/MANIFEST.MF
@@ -1,1 +1,0 @@
-Manifest-Version: 1.0

--- a/src/META-INF/services/net.opentsdb.search.SearchPlugin
+++ b/src/META-INF/services/net.opentsdb.search.SearchPlugin
@@ -1,1 +1,0 @@
-net.opentsdb.search.ElasticSearch

--- a/src/net/opentsdb/search/ElasticSearch.java
+++ b/src/net/opentsdb/search/ElasticSearch.java
@@ -43,11 +43,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import net.opentsdb.core.TSDB;
+import net.opentsdb.stats.StatsCollector;
 import net.opentsdb.meta.Annotation;
 import net.opentsdb.meta.TSMeta;
 import net.opentsdb.meta.UIDMeta;
 import net.opentsdb.search.SearchQuery.SearchType;
 import net.opentsdb.utils.JSON;
+
+import org.hbase.async.Counter;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
@@ -58,7 +61,7 @@ import com.stumbleupon.async.Deferred;
 
 public final class ElasticSearch extends SearchPlugin {
   private static final Logger LOG = LoggerFactory.getLogger(ElasticSearch.class);
-  
+
   private final ConcurrentLinkedQueue<TSMeta> tsuids;
   private final ConcurrentLinkedQueue<String> tsuids_delete;
   private final ConcurrentLinkedQueue<UIDMeta> uids;
@@ -66,7 +69,7 @@ public final class ElasticSearch extends SearchPlugin {
   private final ConcurrentLinkedQueue<Annotation> annotations;
   private final ConcurrentLinkedQueue<Annotation> annotations_delete;
   private final ExecutorService threadpool = Executors.newFixedThreadPool(2);
-  
+
   private Thread[] indexers = null;
   private ImmutableList<HttpHost> hosts;
   private FailoverHttpClient httpClient;
@@ -76,7 +79,15 @@ public final class ElasticSearch extends SearchPlugin {
   private String uidmeta_type = "uidmeta";
   private String annotation_type = "annotation";
   private ESPluginConfig config = null;
-  
+
+  private final Counter tsmetaAdded = new Counter();
+  private final Counter tsmetaDeleted = new Counter();
+  private final Counter uidAdded = new Counter();
+  private final Counter uidDeleted = new Counter();
+  private final Counter annotationAdded = new Counter();
+  private final Counter annotationDeleted = new Counter();
+  private final Counter queriesExecuted = new Counter();
+
   /**
    * Default constructor
    */
@@ -88,7 +99,7 @@ public final class ElasticSearch extends SearchPlugin {
     annotations = new ConcurrentLinkedQueue<Annotation>();
     annotations_delete = new ConcurrentLinkedQueue<Annotation>();
   }
-  
+
   /**
    * Initializes the search plugin, setting up the HTTP client pool and config
    * options.
@@ -103,7 +114,7 @@ public final class ElasticSearch extends SearchPlugin {
     setConfiguration();
 
     // setup a connection pool for reuse
-    PoolingClientConnectionManager http_pool = 
+    PoolingClientConnectionManager http_pool =
       new PoolingClientConnectionManager();
     http_pool.setDefaultMaxPerRoute(
         config.getInt("tsd.search.elasticsearch.pool.max_per_route"));
@@ -118,7 +129,7 @@ public final class ElasticSearch extends SearchPlugin {
       indexers[i].start();
     }
   }
-  
+
   /**
    * Queues the given TSMeta object for indexing
    * @param meta The meta data object to index
@@ -128,6 +139,7 @@ public final class ElasticSearch extends SearchPlugin {
   public Deferred<Object> indexTSMeta(final TSMeta meta) {
     if (meta != null) {
       tsuids.add(meta);
+      tsmetaAdded.increment();
     }
     return Deferred.fromResult(null);
   }
@@ -140,10 +152,11 @@ public final class ElasticSearch extends SearchPlugin {
   public Deferred<Object> deleteTSMeta(final String tsuid) {
     if (tsuid != null) {
       tsuids_delete.add(tsuid);
+      tsmetaDeleted.increment();
     }
     return Deferred.fromResult(null);
   }
-  
+
   /**
    * Queues the given UIDMeta object for indexing
    * @param meta The meta data object to index
@@ -153,6 +166,7 @@ public final class ElasticSearch extends SearchPlugin {
   public Deferred<Object> indexUIDMeta(final UIDMeta meta) {
     if (meta != null) {
       uids.add(meta);
+      uidAdded.increment();
     }
     return Deferred.fromResult(null);
   }
@@ -165,10 +179,11 @@ public final class ElasticSearch extends SearchPlugin {
   public Deferred<Object> deleteUIDMeta(final UIDMeta meta) {
     if (meta != null) {
       uids_delete.add(meta);
+      uidDeleted.increment();
     }
     return null;
   }
-  
+
   /**
    * Indexes an annotation object
    * <b>Note:</b> Unique Document ID = TSUID and Start Time
@@ -180,6 +195,7 @@ public final class ElasticSearch extends SearchPlugin {
   public Deferred<Object> indexAnnotation(final Annotation note) {
     if (note != null) {
       annotations.add(note);
+      annotationAdded.increment();
     }
     return Deferred.fromResult(null);
   }
@@ -195,13 +211,14 @@ public final class ElasticSearch extends SearchPlugin {
   public Deferred<Object> deleteAnnotation(final Annotation note) {
     if (note != null) {
       annotations_delete.add(note);
+      annotationDeleted.increment();
     }
     return Deferred.fromResult(null);
   }
-  
+
   public Deferred<SearchQuery> executeQuery(final SearchQuery query) {
     final Deferred<SearchQuery> result = new Deferred<SearchQuery>();
-    
+
     final StringBuilder uri = new StringBuilder("http://");
     uri.append(hosts.get(0).toHostString());
     uri.append("/").append(index).append("/");
@@ -219,26 +236,27 @@ public final class ElasticSearch extends SearchPlugin {
         break;
     }
     uri.append("/_search");
-    
+
     // setup the query body
     HashMap<String, Object> body = new HashMap<String, Object>(3);
     body.put("size", query.getLimit());
     body.put("from", query.getStartIndex());
-    
+
     HashMap<String, Object> qs = new HashMap<String, Object>(1);
     body.put("query", qs);
     HashMap<String, String> query_string = new HashMap<String, String>(1);
     query_string.put("query", query.getQuery());
     qs.put("query_string", query_string);
-    
+
     final Request request = Request.Post(uri.toString());
     request.bodyByteArray(JSON.serializeToBytes(body));
-    
+
     final Async async = Async.newInstance().use(threadpool);
     async.execute(request, new SearchCB(query, result));
+    queriesExecuted.increment();
     return result;
   }
-  
+
   /**
    * Gracefully closes connections
    */
@@ -252,22 +270,31 @@ public final class ElasticSearch extends SearchPlugin {
   public String version() {
     return "2.0.0";
   }
-  
+
+  @Override
+  public void collectStats(final StatsCollector collector) {
+    collector.record("search.tsmeta_added", tsmetaAdded.get());
+    collector.record("search.tsmeta_deleted", tsmetaDeleted.get());
+    collector.record("search.uid_added", uidAdded.get());
+    collector.record("search.uid_deleted", uidDeleted.get());
+    collector.record("search.queries_executed", queriesExecuted.get());
+  }
+
   /**
    * Parses semicoln separated hosts from a config line into a host list. If
-   * a given host includes a port, e.g. "host:port", the port will be parsed, 
+   * a given host includes a port, e.g. "host:port", the port will be parsed,
    * otherwise port 9200 will be used.
    * @param config The config line to parse
-   * @throws IllegalArgumentException if the line was empty or no hosts were 
+   * @throws IllegalArgumentException if the line was empty or no hosts were
    * parsed
-   * @throws NumberFormatException if a parsed port can't be converted to an 
+   * @throws NumberFormatException if a parsed port can't be converted to an
    * integer
    */
   private void setHosts(final String config) {
     if (config == null || config.isEmpty()) {
       throw new IllegalArgumentException("The hosts config was empty");
     }
-    
+
     Builder<HttpHost> host_list = ImmutableList.<HttpHost>builder();
     String[] split_hosts = config.split(";");
     for (String host : split_hosts) {
@@ -284,7 +311,7 @@ public final class ElasticSearch extends SearchPlugin {
           "No hosts were found to load into the list");
     }
   }
-  
+
   /**
    * Helper that loads config settings and throws exceptions if something is
    * amiss.
@@ -292,16 +319,16 @@ public final class ElasticSearch extends SearchPlugin {
    * @throws NumberFormatException if a config value is invalid
    */
   private void setConfiguration() {
-    final String host_config = 
+    final String host_config =
       config.getString("tsd.search.elasticsearch.hosts");
     if (host_config == null || host_config.isEmpty()) {
       throw new IllegalArgumentException("Missing search hosts configuration");
     }
     setHosts(host_config);
-    
+
     // set thread count
     index_threads = config.getInt("tsd.search.elasticsearch.index_threads");
-    
+
     // set index/types
     index = config.getString("tsd.search.elasticsearch.index");
     if (index == null || index.isEmpty()) {
@@ -311,14 +338,14 @@ public final class ElasticSearch extends SearchPlugin {
     if (tsmeta_type == null || tsmeta_type.isEmpty()) {
       throw new IllegalArgumentException(
           "Invalid tsmeta_type configuration value");
-    }    
+    }
     uidmeta_type = config.getString("tsd.search.elasticsearch.uidmeta_type");
     if (uidmeta_type == null || uidmeta_type.isEmpty()) {
       throw new IllegalArgumentException(
           "Invalid uidmeta_type configuration value");
     }
   }
-  
+
   /**
    * A worker thread that watches all of the queues, pushing waiting objects out
    * to the indexer
@@ -327,50 +354,50 @@ public final class ElasticSearch extends SearchPlugin {
     public SearchIndexer() {
       super("SearchIndexer");
     }
-    
+
     /**
      * Loops indefinitely and processes the queues
      */
     public void run() {
       // as long as we find some data, keep looping, otherwise sleep a bit
-      while (true) { 
+      while (true) {
         boolean found_one = false;
         final TSMeta tsmeta = tsuids.poll();
         if (tsmeta != null) {
           indexTSUID(tsmeta);
           found_one = true;
         }
-        
+
         final String tsuid = tsuids_delete.poll();
         if (tsuid != null) {
           deleteTSUID(tsuid);
           found_one = true;
         }
-        
+
         UIDMeta uidmeta = uids.poll();
         if (uidmeta != null) {
           indexUID(uidmeta);
           found_one = true;
         }
-        
-        uidmeta = uids_delete.poll(); 
+
+        uidmeta = uids_delete.poll();
         if (uidmeta != null) {
           deleteUID(uidmeta);
           found_one = true;
         }
-        
+
         Annotation note = annotations.poll();
         if (note != null) {
           indexAnnotation(note);
           found_one = true;
         }
-        
+
         note = annotations_delete.poll();
         if (note != null) {
           deleteAnnotation(note);
           found_one = true;
         }
-        
+
         if (!found_one) {
           try {
             Thread.sleep(1000);
@@ -381,13 +408,13 @@ public final class ElasticSearch extends SearchPlugin {
         }
       }
     }
-    
+
     /**
      * Pushes a TSMeta object to the Elastic Search boxes over HTTP
      * @param meta The meta data to publish
      */
-    private void indexTSUID(final TSMeta meta) { 
-      final HttpPost request = new HttpPost("/" + index + "/" + 
+    private void indexTSUID(final TSMeta meta) {
+      final HttpPost request = new HttpPost("/" + index + "/" +
           tsmeta_type + "/" + meta.getTSUID() + "?replication=async");
       try {
         request.setEntity(new StringEntity(JSON.serializeToString(meta)));
@@ -398,41 +425,41 @@ public final class ElasticSearch extends SearchPlugin {
       if (response == null) {
         LOG.trace("Successfully indexed TSUID: " + meta);
       } else {
-        LOG.error("Failed to indexed TSUID: " + meta + " with error: " + 
+        LOG.error("Failed to indexed TSUID: " + meta + " with error: " +
             response);
       }
     }
-    
+
     /**
      * Deletes a TSMeta document from the search servers
      * @param meta The meta data to delete
      */
     private void deleteTSUID(final String tsuid) {
-      final HttpDelete request = new HttpDelete("/" + index + "/" + 
-          tsmeta_type + "/" + tsuid + 
+      final HttpDelete request = new HttpDelete("/" + index + "/" +
+          tsmeta_type + "/" + tsuid +
           "?replication=async");
       final String response = execute(request);
       if (response == null) {
         LOG.trace("Successfully deleted TSUID: " + tsuid);
       } else {
-        LOG.error("Failed to delete TSUID: " + tsuid + " with error: " + 
+        LOG.error("Failed to delete TSUID: " + tsuid + " with error: " +
             response);
       }
     }
-    
+
     /**
      * Pushes a UIDMeta object to the Elastic Search boxes over HTTP
      * @param meta The meta data to publish
      */
     private void indexUID(final UIDMeta meta) {
-      final HttpPost request = new HttpPost("/" + index + "/" + 
-          uidmeta_type + "/" + meta.getType().toString() + meta.getUID() + 
+      final HttpPost request = new HttpPost("/" + index + "/" +
+          uidmeta_type + "/" + meta.getType().toString() + meta.getUID() +
           "?replication=async");
       try {
         request.setEntity(new StringEntity(JSON.serializeToString(meta)));
       } catch (UnsupportedEncodingException e) {
         LOG.error("Encoding Error", e);
-      }      
+      }
       final String response = execute(request);
       if (response == null) {
         LOG.trace("Successfully indexed UID: " + meta);
@@ -440,14 +467,14 @@ public final class ElasticSearch extends SearchPlugin {
         LOG.error("Failed to index UID: " + meta + " with error: " + response);
       }
     }
-    
+
     /**
      * Deletes a UIDMeta document from the search servers
      * @param meta The meta data to delete
      */
     private void deleteUID(final UIDMeta meta) {
-      final HttpDelete request = new HttpDelete("/" + index + "/" + 
-          uidmeta_type + "/" + meta.getType().toString() + meta.getUID() + 
+      final HttpDelete request = new HttpDelete("/" + index + "/" +
+          uidmeta_type + "/" + meta.getType().toString() + meta.getUID() +
           "?replication=async");
       final String response = execute(request);
       if (response == null) {
@@ -456,49 +483,49 @@ public final class ElasticSearch extends SearchPlugin {
         LOG.error("Failed to delete UID: " + meta + " with error: " + response);
       }
     }
-    
+
     /**
      * Pushes an annotation object to the Elastic Search boexes over HTTP
      * @param note The annotation to index
      */
     private void indexAnnotation(final Annotation note) {
-      final HttpPost request = new HttpPost("/" + index + "/" + 
-          annotation_type + "/" + note.getStartTime() + 
+      final HttpPost request = new HttpPost("/" + index + "/" +
+          annotation_type + "/" + note.getStartTime() +
           note != null ? note.getTSUID() : "" + "?replication=async");
       try {
         request.setEntity(new StringEntity(JSON.serializeToString(note)));
       } catch (UnsupportedEncodingException e) {
         LOG.error("Encoding Error", e);
-      }      
+      }
       final String response = execute(request);
       if (response == null) {
         LOG.trace("Successfully indexed annotation: " + note);
       } else {
-        LOG.error("Failed to index annotation: " + note + " with error: " + 
+        LOG.error("Failed to index annotation: " + note + " with error: " +
             response);
       }
     }
-    
+
     /**
      * Deletes an annotation document from the search servers
      * @param note The annotation to delete
      */
     private void deleteAnnotation(final Annotation note) {
-      final HttpDelete request = new HttpDelete("/" + index + "/" + 
-          annotation_type + "/" +  note.getStartTime() + 
+      final HttpDelete request = new HttpDelete("/" + index + "/" +
+          annotation_type + "/" +  note.getStartTime() +
           note != null ? note.getTSUID() : "" + "?replication=async");
       final String response = execute(request);
       if (response == null) {
         LOG.trace("Successfully deleted annotation: " + note);
       } else {
-        LOG.error("Failed to delete annotation: " + note + " with error: " + 
+        LOG.error("Failed to delete annotation: " + note + " with error: " +
             response);
       }
     }
-    
+
     /**
      * Executes an HTTP request against the ES servers and returns an error
-     * string if the request fails. 
+     * string if the request fails.
      * TODO need to parse the output, for now we're just dumping the full JSON
      * response
      * @param request The request to execute
@@ -506,10 +533,10 @@ public final class ElasticSearch extends SearchPlugin {
      */
     private String execute(final HttpRequest request) {
       try {
-        final HttpContext context = new BasicHttpContext();        
+        final HttpContext context = new BasicHttpContext();
         HttpResponse response = httpClient.execute(hosts, request, context);
         HttpEntity entity = response.getEntity();
-        if (response.getStatusLine().getStatusCode() == 200 || 
+        if (response.getStatusLine().getStatusCode() == 200 ||
             response.getStatusLine().getStatusCode() == 201){
           if (entity != null) {
             EntityUtils.consume(entity);
@@ -538,12 +565,12 @@ public final class ElasticSearch extends SearchPlugin {
 
     final SearchQuery query;
     final Deferred<SearchQuery> result;
-    
+
     public SearchCB(final SearchQuery query, final Deferred<SearchQuery> result) {
       this.query = query;
       this.result = result;
     }
-    
+
     @Override
     public void cancelled() {
       result.callback(null);
@@ -551,14 +578,14 @@ public final class ElasticSearch extends SearchPlugin {
 
     @Override
     public void completed(final Content content) {
-      
+
       final JsonParser jp = JSON.parseToStream(content.asStream());
       if (jp == null) {
         LOG.warn("Query response was null or empty");
         result.callback(null);
         return;
       }
-      
+
       try {
         JsonToken next = jp.nextToken();
         if (next != JsonToken.START_OBJECT) {
@@ -566,22 +593,22 @@ public final class ElasticSearch extends SearchPlugin {
           result.callback(null);
           return;
         }
-      
+
         final List<Object> objects = new ArrayList<Object>();
-        
+
         // loop through the JSON structure
         String parent = "";
         String last = "";
-        
+
         while (jp.nextToken() != null) {
           String fieldName = jp.getCurrentName();
           if (fieldName != null)
             last = fieldName;
-          
-          if (jp.getCurrentToken() == JsonToken.START_ARRAY || 
+
+          if (jp.getCurrentToken() == JsonToken.START_ARRAY ||
               jp.getCurrentToken() == JsonToken.START_OBJECT)
             parent = last;
-          
+
           if (fieldName != null && fieldName.equals("_source")) {
             if (jp.nextToken() == JsonToken.START_OBJECT) {
               // parse depending on type
@@ -595,11 +622,11 @@ public final class ElasticSearch extends SearchPlugin {
                   } else if (query.getType() == SearchType.TSUIDS) {
                     objects.add(meta.getTSUID());
                   } else {
-                    final HashMap<String, Object> map = 
+                    final HashMap<String, Object> map =
                       new HashMap<String, Object>(3);
                     map.put("tsuid", meta.getTSUID());
                     map.put("metric", meta.getMetric().getName());
-                    final HashMap<String, String> tags = 
+                    final HashMap<String, String> tags =
                       new HashMap<String, String>(meta.getTags().size() / 2);
                     int idx = 0;
                     String name = "";
@@ -635,12 +662,12 @@ public final class ElasticSearch extends SearchPlugin {
             LOG.trace("Time taken: [" + jp.getValueAsInt() + "]");
             query.setTime(jp.getValueAsInt());
           }
-          
+
           query.setResults(objects);
         }
-        
+
         result.callback(query);
-        
+
       } catch (JsonParseException e) {
         LOG.error("Query failed", e);
         throw new RuntimeException(e);
@@ -655,6 +682,5 @@ public final class ElasticSearch extends SearchPlugin {
       LOG.error("Query failed", e);
       throw new RuntimeException(e);
     }
-    
   }
 }


### PR DESCRIPTION
Summary:
Build against opentsdb 2.1.
Implement stats collector method
Use scl-over-slf4j to make logging work for httpcomponents
update jackson
use maven service plugin to generate META-INF
